### PR TITLE
Split on correct divider in AWS Credential file

### DIFF
--- a/opinel/utils.py
+++ b/opinel/utils.py
@@ -430,9 +430,9 @@ def read_creds_from_aws_credentials_file(profile_name, credentials_file = aws_cr
                         profile_found = False
                 if profile_found:
                     if re_access_key.match(line):
-                        key_id = (line.split(' ')[2]).rstrip()
+                        key_id = line.split("=")[1].strip(" ")
                     elif re_secret_key.match(line):
-                        secret = (line.split(' ')[2]).rstrip()
+                        secret = line.split("=")[1].strip(" ")
                     elif re_mfa_serial.match(line):
                         mfa_serial = (line.split(' ')[2]).rstrip()
                     elif re_session_token.match(line):


### PR DESCRIPTION
Currently Opinel relies on the fact that there may be a space before an
access/secret key within the ~/.aws/credentials file (e.g.
"aws_access_key_id = AKI..."  The official package however does support
defining attributes without space separation. This commit thus supports this use
case.